### PR TITLE
Add an orientation attribute so that the display can be used the other way up.

### DIFF
--- a/examples/hello-world.py
+++ b/examples/hello-world.py
@@ -7,3 +7,7 @@
 import scrollbit
 
 scrollbit.scroll("Hello {HEART} World!")
+
+scrollbit.orientation = scrollbit.INVERT
+
+scrollbit.scroll("Goodbye {SKULL} Earth!")

--- a/library/scrollbit.py
+++ b/library/scrollbit.py
@@ -3,6 +3,10 @@ from microbit import sleep, i2c, Image as I
 WIDTH = 17
 HEIGHT = 7
 
+orientation = 0
+NORMAL = 0
+INVERT = 1
+
 _f = 0
 _b = bytearray(145)
 _i = [getattr(I,x) for x in dir(I) if hasattr(getattr(I,x),'get_pixel')]
@@ -99,7 +103,8 @@ def get_pixel(col, row):
     return _b[_pixel_addr(col, row)]
     
 def _pixel_addr(x, y):
-    y = 7 - (y + 1)
+    y =  (7 - (y + 1))*(1 - orientation) + orientation*y
+    x = (17 - (x + 1))*orientation + (1 - orientation)*x
 
     if x > 8:
         x = x - 8

--- a/library/scrollbit.source.py
+++ b/library/scrollbit.source.py
@@ -3,6 +3,10 @@ from microbit import sleep, i2c, Image
 WIDTH = 17
 HEIGHT = 7
 
+orientation = 0
+NORMAL = 0
+INVERT = 1
+
 _ADDRESS = 0x74
 
 _MODE_REGISTER = 0x00
@@ -121,7 +125,8 @@ def get_pixel(col, row):
     return _buf[_pixel_addr(col, row)]
     
 def _pixel_addr(x, y):
-    y = 7 - (y + 1)
+    y =  (7 - (y + 1))*(1 - orientation) + orientation*y
+    x = (17 - (x + 1))*orientation + (1 - orientation)*x
 
     if x > 8:
         x = x - 8


### PR DESCRIPTION
This is useful for when holding the microbit as a controller with the scrollbit
as the display above it.

Syntax:

scrollbit.orientation = scrollbit.NORMAL
scrollbit.orientation = scrollbit.INVERT

Also added to the hello-world.py example to demonstrate backwards text.