### PR TITLE
Adding a troubleshooting section to README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,10 @@ Call this to display your changes on scroll:bit.
 `scrollbit.clear()`
 
 Call this to clear the scroll:bit display.
+
+# Troubleshooting
+
+## Memory Error
+
+If you receive a Memory Error exception on the line where you `import scroll` bit the best resolution is to copy the contents of `scrollbit.py` into your `main.py` file.
+

--- a/README.md
+++ b/README.md
@@ -67,5 +67,5 @@ Call this to clear the scroll:bit display.
 
 ## Memory Error
 
-If you receive a Memory Error exception on the line where you `import scroll` bit the best resolution is to copy the contents of `scrollbit.py` into your `main.py` file.
+If you receive a Memory Error exception on the line where you `import scrollbit` bit the best resolution is to copy the contents of `scrollbit.py` into your `main.py` file.
 


### PR DESCRIPTION
I spend a couple of days trying to debug a Memory Error issue before discovering that I might should copy the code into my `main.py` file. To help future debuggers I'm suggesting a troubleshooting section to go on the `README.md` page.

My change is small and the description brief as it's just a pointer.